### PR TITLE
Remove explicit type specification 

### DIFF
--- a/android/src/main/java/com/reactnativehintrequestpicker/HintRequestPickerModule.kt
+++ b/android/src/main/java/com/reactnativehintrequestpicker/HintRequestPickerModule.kt
@@ -49,7 +49,7 @@ class HintRequestPickerModule(private val reactContext: ReactApplicationContext)
     if (requestCode === Constants.PHONE_PICKER_REQUEST) {
       val map = Arguments.createMap()
       if (resultCode === RESULT_OK) {
-        val credential: Credential? = data.getParcelableExtra(Credential.EXTRA_KEY)
+        val credential = data.getParcelableExtra<Credential>(Credential.EXTRA_KEY)
         if (credential == null) {
           return;
         }
@@ -63,7 +63,7 @@ class HintRequestPickerModule(private val reactContext: ReactApplicationContext)
     else if (requestCode === Constants.EMAIL_PICKER_REQUEST) {
       val map = Arguments.createMap()
       if (resultCode === RESULT_OK) {
-        val credential: Credential? = data.getParcelableExtra(Credential.EXTRA_KEY)
+        val credential = data.getParcelableExtra<Credential>(Credential.EXTRA_KEY)
         if (credential == null) {
           return;
         }


### PR DESCRIPTION
When I tried to install the package in React Native project faced the following issue
This PR is fix for it

```
error Failed to install the app. Make sure you have the Android development environment set up: https://reactnative.dev/docs/environment-setup.
Error: Command failed: ./gradlew app:installDebug -PreactNativeDevServerPort=8081
e: /Users/manohar/Documents/AwesomeProject/node_modules/react-native-hint-request-picker/android/src/main/java/com/reactnativehintrequestpicker/HintRequestPickerModule.kt: (52, 43): Type inference failed. Expected type mismatch: inferred type is Credential? but Credential was expected
e: /Users/manohar/Documents/AwesomeProject/node_modules/react-native-hint-request-picker/android/src/main/java/com/reactnativehintrequestpicker/HintRequestPickerModule.kt: (63, 43): Type inference failed. Expected type mismatch: inferred type is Credential? but Credential was expected
```